### PR TITLE
gitsecure auto-remediation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,12 @@ WORKDIR /go/src/github.com/multi-stage3
 RUN go get -d -v golang.org/x/net/html  
 COPY app.go .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
+#GITSECURE REMEDIATION 
+RUN  pip install mistune0.8.1  Jinja22.10.1 \ 
+     SQLAlchemy1.3.0  Werkzeug0.15.3 \ 
+     nltk3.4.5  Pillow6.2.0 \ 
+     
+
 
 
 FROM alpine:latest  


### PR DESCRIPTION
# GitSecure Vulnerablility Report

| Control ID | Section | Description |
|------------|---------|-------------|
| RA-5 | Risk Assessment | Vulnerability Scanning |
| CA-7 | Security Assessment and Authorization | Continuous Monitoring |
| SA-12 | System and Services Acquisition | Supply Chain Protection |
| SI-2 | System and Information Integrity | Flaw Remediation |
| CM-4 | Configuration Management | Security Impact Analysis |
| CA-2 | Security Assessment and Authorization | Security Assessments |

<p>
<details>
<summary>  <strong>  For Dockerfile: </strong>Dockerfile <strong> Stage: </strong>shri4u/myapp-base:0.1
  </summary> 

:white_check_mark: OS Packages Safe 
:x: Pip Packages Safe 
:white_check_mark: Node Packages Safe 
# Detailed Package Analysis 
<details>
<summary>
<a class="button">  <strong> OS Packages [Expand for more information] </strong>
</a></summary>

</details>

<details>
<summary>
<a class="button"> <strong> Python Packages [Expand for more information] </strong></a></summary>
<p>
<details>
<summary> Package Name: mistune | Current Version: 0.7.4  <strong>(VULNERABLE)</strong>
  </summary> 

*Recommended update* : 0.8.1 
*CVE* : CVE-2017-16876 
*Severity* : MODERATE 
*Link* : https://nvd.nist.gov/vuln/detail/CVE-2017-16876 
*Description* : Cross-site scripting (XSS) vulnerability in the _keyify function in mistune.py in Mistune before 0.8.1 allows remote attackers to inject arbitrary web script or HTML by leveraging failure to escape the "key" argument. 


%!(EXTRA string=Cross-site scripting (XSS) vulnerability in the _keyify function in mistune.py in Mistune before 0.8.1 allows remote attackers to inject arbitrary web script or HTML by leveraging failure to escape the "key" argument.)*CVE* : GHSA-98gj-wwxm-cj3h 
*Severity* : MODERATE 
*Link* :  
*Description* : Cross-site scripting (XSS) vulnerability in the _keyify function in mistune.py in Mistune before 0.8.1 allows remote attackers to inject arbitrary web script or HTML by leveraging failure to escape the "key" argument. 


%!(EXTRA string=Cross-site scripting (XSS) vulnerability in the _keyify function in mistune.py in Mistune before 0.8.1 allows remote attackers to inject arbitrary web script or HTML by leveraging failure to escape the "key" argument.)</details>
</p>

<p>
<details>
<summary> Package Name: Jinja2 | Current Version: 2.9.6  <strong>(VULNERABLE)</strong>
  </summary> 

*Recommended update* : 2.10.1 
*CVE* : CVE-2019-10906 
*Severity* : HIGH 
*Link* : https://nvd.nist.gov/vuln/detail/CVE-2019-10906 
*Description* : In Pallets Jinja before 2.10.1, str.format_map allows a sandbox escape. 


%!(EXTRA string=In Pallets Jinja before 2.10.1, str.format_map allows a sandbox escape.)*CVE* : GHSA-462w-v97r-4m45 
*Severity* : HIGH 
*Link* :  
*Description* : In Pallets Jinja before 2.10.1, str.format_map allows a sandbox escape. 


%!(EXTRA string=In Pallets Jinja before 2.10.1, str.format_map allows a sandbox escape.)</details>
</p>

<p>
<details>
<summary> Package Name: SQLAlchemy | Current Version: 1.1.13  <strong>(VULNERABLE)</strong>
  </summary> 

*Recommended update* : 1.3.0 
*CVE* : CVE-2019-7164 
*Severity* : MODERATE 
*Link* : https://nvd.nist.gov/vuln/detail/CVE-2019-7164 
*Description* : SQLAlchemy through 1.2.17 and 1.3.x through 1.3.0b2 allows SQL Injection via the order_by parameter. 


%!(EXTRA string=SQLAlchemy through 1.2.17 and 1.3.x through 1.3.0b2 allows SQL Injection via the order_by parameter.)*CVE* : GHSA-887w-45rq-vxgf 
*Severity* : MODERATE 
*Link* :  
*Description* : SQLAlchemy through 1.2.17 and 1.3.x through 1.3.0b2 allows SQL Injection via the order_by parameter. 


%!(EXTRA string=SQLAlchemy through 1.2.17 and 1.3.x through 1.3.0b2 allows SQL Injection via the order_by parameter.)*CVE* : CVE-2019-7548 
*Severity* : MODERATE 
*Link* : https://nvd.nist.gov/vuln/detail/CVE-2019-7548 
*Description* : SQLAlchemy 1.2.17 has SQL Injection when the group_by parameter can be controlled. 


%!(EXTRA string=SQLAlchemy 1.2.17 has SQL Injection when the group_by parameter can be controlled.)*CVE* : GHSA-38fc-9xqv-7f7q 
*Severity* : MODERATE 
*Link* :  
*Description* : SQLAlchemy 1.2.17 has SQL Injection when the group_by parameter can be controlled. 


%!(EXTRA string=SQLAlchemy 1.2.17 has SQL Injection when the group_by parameter can be controlled.)</details>
</p>

<p>
<details>
<summary> Package Name: Werkzeug | Current Version: 0.12.2  <strong>(VULNERABLE)</strong>
  </summary> 

*Recommended update* : 0.15.3 
*CVE* : CVE-2019-14806 
*Severity* : HIGH 
*Link* : https://nvd.nist.gov/vuln/detail/CVE-2019-14806 
*Description* : Pallets Werkzeug before 0.15.3, when used with Docker, has insufficient debugger PIN randomness because Docker containers share the same machine id. 


%!(EXTRA string=Pallets Werkzeug before 0.15.3, when used with Docker, has insufficient debugger PIN randomness because Docker containers share the same machine id.)*CVE* : GHSA-gq9m-qvpx-68hc 
*Severity* : HIGH 
*Link* :  
*Description* : Pallets Werkzeug before 0.15.3, when used with Docker, has insufficient debugger PIN randomness because Docker containers share the same machine id. 


%!(EXTRA string=Pallets Werkzeug before 0.15.3, when used with Docker, has insufficient debugger PIN randomness because Docker containers share the same machine id.)</details>
</p>

<p>
<details>
<summary> Package Name: nltk | Current Version: 3.2  <strong>(VULNERABLE)</strong>
  </summary> 

*Recommended update* : 3.4.5 
*CVE* : CVE-2019-14751 
*Severity* : HIGH 
*Link* : https://nvd.nist.gov/vuln/detail/CVE-2019-14751 
*Description* : NLTK Downloader before 3.4.5 is vulnerable to a directory traversal, allowing attackers to write arbitrary files via a ../ (dot dot slash) in an NLTK package (ZIP archive) that is mishandled during extraction. 


%!(EXTRA string=NLTK Downloader before 3.4.5 is vulnerable to a directory traversal, allowing attackers to write arbitrary files via a ../ (dot dot slash) in an NLTK package (ZIP archive) that is mishandled during extraction.)*CVE* : GHSA-mr7p-25v2-35wr 
*Severity* : HIGH 
*Link* :  
*Description* : NLTK Downloader before 3.4.5 is vulnerable to a directory traversal, allowing attackers to write arbitrary files via a ../ (dot dot slash) in an NLTK package (ZIP archive) that is mishandled during extraction. 


%!(EXTRA string=NLTK Downloader before 3.4.5 is vulnerable to a directory traversal, allowing attackers to write arbitrary files via a ../ (dot dot slash) in an NLTK package (ZIP archive) that is mishandled during extraction.)</details>
</p>

<p>
<details>
<summary> Package Name: Pillow | Current Version: 4.2.1  <strong>(VULNERABLE)</strong>
  </summary> 

*Recommended update* : 6.2.0 
*CVE* : CVE-2019-16865 
*Severity* : LOW 
*Link* : https://nvd.nist.gov/vuln/detail/CVE-2019-16865 
*Description* : An issue was discovered in Pillow before 6.2.0. When reading specially crafted invalid image files, the library can either allocate very large amounts of memory or take an extremely long period of time to process the image. 


%!(EXTRA string=An issue was discovered in Pillow before 6.2.0. When reading specially crafted invalid image files, the library can either allocate very large amounts of memory or take an extremely long period of time to process the image.)*CVE* : GHSA-j7mj-748x-7p78 
*Severity* : LOW 
*Link* :  
*Description* : An issue was discovered in Pillow before 6.2.0. When reading specially crafted invalid image files, the library can either allocate very large amounts of memory or take an extremely long period of time to process the image. 


%!(EXTRA string=An issue was discovered in Pillow before 6.2.0. When reading specially crafted invalid image files, the library can either allocate very large amounts of memory or take an extremely long period of time to process the image.)</details>
</p>


</details>

<details>
<summary>
<a class="button"> <strong> Node Packages [Expand for more information] </strong></a></summary>

</details>

</details>
</p>

